### PR TITLE
fix: resolve missing bin path in PATH

### DIFF
--- a/Formula/unwarp.rb
+++ b/Formula/unwarp.rb
@@ -4,7 +4,7 @@ class Unwarp < Formula
   url "https://github.com/loozhengyuan/unwarp.git",
     tag: "v0.1.0"
   license "MIT"
-  revision 4
+  revision 5
   head "https://github.com/loozhengyuan/unwarp.git",
     branch: "main"
 
@@ -15,7 +15,9 @@ class Unwarp < Formula
   service do
     run "#{opt_bin}/unwarp"
     keep_alive always: true
-    environment_variables PATH: std_service_path_env
+    # NOTE: `/usr/local/bin` may not be always be in `std_service_path_env`
+    # depending on the target os and architecture so we explicitly add it.
+    environment_variables PATH: "#{std_service_path_env}:/usr/local/bin"
     log_path "#{var}/log/unwarp.log"
     error_log_path "#{var}/log/unwarp.log"
   end


### PR DESCRIPTION
The `unwarp` service is expected to have `/usr/local/bin` in its `PATH` environment variable and using the `std_service_path_env` variable has always worked because [Brew is installed to `/usr/local` on Intel macOS](https://docs.brew.sh/Installation). On Apple Silicon macOS and Linux environments, this will cause the service to fail because the dependent binary `warp-cli` cannot be found.

To fix this, we explicitly add `/usr/local/bin` to the `PATH` environment variable. To test the changes, run the following command:

```shell
curl -fsSL --output /tmp/unwarp.rb --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/loozhengyuan/homebrew-tap/fix/warp-cli-not-found/Formula/unwarp.rb && brew install --formula /tmp/unwarp.rb && rm /tmp/unwarp.rb
```