### PR TITLE
ci: fix failing pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   test:
     name: test
-    runs-on: macos-12
+    runs-on: macos-15
     timeout-minutes: 10
 
     steps:
@@ -28,7 +28,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.2.4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}


### PR DESCRIPTION
This commit makes the following changes to make the CI pipeline pass:

- Upgrade runner tag to `macos-15` because previous runner tag has been removed[1] on 2024-12-03.
- Upgrade `actions/cache` to latest version due to breaking changes[2] with the upgrade of the cache backend on 2025-02-01.

[1]: https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/
[2]: https://github.com/actions/cache/discussions/1510