### PR TITLE
ci: disable bump on push/pr

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,12 +1,6 @@
 name: bump
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: "0 10 * * *" # Daily at 18:00hrs SGT
   workflow_dispatch:


### PR DESCRIPTION
The new `bump` workflow is only intended to be ran on `schedule` and `workflow_dispatch`.