### PR TITLE
feat: add support for KiCad casks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
         run: brew install-bundler-gems
 
       # TODO: Figure how to test all formulae by default
+      # TODO: Figure out idiomatic way to test casks
       - name: Run tests
         run: |
           brew test-bot --testing-formulae unwarp
+          brew install --cask kicad
+          brew uninstall --cask kicad
+          brew install --cask kicad@8
+          brew uninstall --cask kicad@8

--- a/Casks/kicad.rb
+++ b/Casks/kicad.rb
@@ -1,0 +1,37 @@
+cask "kicad" do
+  version "9.0.4"
+  sha256 "eb3d939868cfe40948060c8f82867c127839eed968768b245651b50992ceed4b"
+
+  url "https://github.com/KiCad/kicad-source-mirror/releases/download/#{version}/kicad-unified-universal-#{version}.dmg",
+      verified: "github.com/KiCad/kicad-source-mirror/"
+  name "KiCad"
+  desc "Electronics design automation suite"
+  homepage "https://kicad.org/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  conflicts_with cask: [
+    "kicad@9",
+    "kicad@8",
+  ]
+  depends_on macos: ">= :big_sur"
+
+  suite "KiCad"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/dxf2idf"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/idf2vrml"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/idfcyl"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/idfrect"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
+  artifact "demos", target: "/Library/Application Support/kicad/demos"
+
+  zap delete: "/Library/Application Support/kicad",
+      trash:  [
+        "~/Library/Application Support/kicad",
+        "~/Library/Preferences/kicad",
+        "~/Library/Preferences/org.kicad-pcb.*",
+        "~/Library/Saved Application State/org.kicad-pcb.*",
+      ]
+end

--- a/Casks/kicad@8.rb
+++ b/Casks/kicad@8.rb
@@ -1,0 +1,38 @@
+cask "kicad@8" do
+  version "8.0.9"
+  sha256 "865a96ff02e9dc4d5e6d3554d8224b7d780aae7b2975329d911dfe57820ba07a"
+
+  url "https://github.com/KiCad/kicad-source-mirror/releases/download/#{version}/kicad-unified-universal-#{version}.dmg",
+      verified: "github.com/KiCad/kicad-source-mirror/"
+  name "KiCad"
+  desc "Electronics design automation suite"
+  homepage "https://kicad.org/"
+
+  livecheck do
+    url :url
+    regex(/^v?(8(?:\.\d+)+)$/i)
+    strategy :github_releases
+  end
+
+  conflicts_with cask: [
+    "kicad",
+    "kicad@9",
+  ]
+  depends_on macos: ">= :big_sur"
+
+  suite "KiCad"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/dxf2idf"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/idf2vrml"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/idfcyl"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/idfrect"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
+  artifact "demos", target: "/Library/Application Support/kicad/demos"
+
+  zap delete: "/Library/Application Support/kicad",
+      trash:  [
+        "~/Library/Application Support/kicad",
+        "~/Library/Preferences/kicad",
+        "~/Library/Preferences/org.kicad-pcb.*",
+        "~/Library/Saved Application State/org.kicad-pcb.*",
+      ]
+end


### PR DESCRIPTION
This commit adds support for the KiCad casks, particular the `kicad@8` cask.

The `kicad` cask is already available from Homebrew core but version-scoped releases are not available. This is mostly useful when working between libraries and applications during the period when KiCad upgrades to the next major version and there is a requirement to open files using the older release.