### PR TITLE
ci: switch to fine-grained access tokens

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,9 +17,6 @@ jobs:
     name: bump
     runs-on: macos-15
     timeout-minutes: 10
-    permissions:
-      contents: write       # Required to push commits
-      pull-requests: write  # Required to create PRs
 
     steps:
       - name: Set up Homebrew
@@ -52,10 +49,11 @@ jobs:
       # and operates on all formulae/casks within a tap.
       - name: Bump packages
         env:
-          # NOTE: `GITHUB_TOKEN` is intentionally used even though created PRs does
-          # not trigger GitHub Action workflows and requires manual rebase. Given
-          # that updates are infrequent, the cost of manual rebase is lesser than
-          # rotating tokens.
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NOTE: Using `GITHUB_TOKEN` also works but PRs created this way
+          # will not trigger CI runs required to validate the changes. As such,
+          # even though using a fine-grained access token requires periodic
+          # token rotation, it is preferred of `GITHUB_TOKEN`.
+          # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
         run: |
           brew bump --open-pr --no-fork --tap loozhengyuan/tap


### PR DESCRIPTION
This commit switches the primary authentication mechanism for bumping formulae/casks from `GITHUB_TOKEN` to Fine-grained Access Tokens.

This token is required in order for the `brew bump` command to create PRs. Both `GITHUB_TOKEN` and Fine-grained Access Tokens work for this use case, but they each have different quirks.

When using `GITHUB_TOKEN`, PRs are created by a neutral bot user and does not require token rotation. However, PRs created this way does not trigger CI runs required to validate the changes[1], which typically requires manual rebase.

When using Fine-grained Access Tokens, PRs are created by the token owner and it triggers CI runs as expected. However, one notable downside is that it requires token rotation.

It was previously decided but `GITHUB_TOKEN` was preferable because version bumps are less common than token rotation events. However, with new formulae/casks added to the repo, it now makes more sense to just use Fine-grained Access Tokens for this purpose. From a security perspective, Fine-grained Access Tokens are still reasonable because they are scoped to only allow specific actions on this repository only.

[1]: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow